### PR TITLE
feat: add JsonObjectNode merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,47 @@ node.update({
 
 The `update` method reconciles the new content with the existing document, preserving comments, indentation, and spacing.
 
+To merge two documents while preserving comments, use the `merge` method:
+
+```ts
+
+const destinationCode = `{
+  // Destination pre-foo comment
+  "foo": "value",
+  // Destination post-foo comment
+  "baz": [1, 2, 3]
+}
+`;
+
+const sourceCode = `{
+  /* Source pre-bar comment */
+  "bar": 123, /* Inline comment */
+  /* Source post-bar comment */
+  "baz": true /* Another inline comment */
+}
+`;
+
+const source = JsonParser.parse(sourceCode, JsonObjectNode);
+const destination = JsonParser.parse(destinationCode, JsonObjectNode);
+
+console.log(JsonObjectNode.merge(source, destination).toString());
+```
+
+Output:
+
+```json5
+{
+  // Destination pre-foo comment
+  "foo": "value",
+  /* Source pre-bar comment */
+  "bar": 123, /* Inline comment */
+  /* Source post-bar comment */
+  "baz": true /* Another inline comment */
+}
+```
+
+The `merge` method removes any existing destination properties that clash with source, along with their leading/trailing trivia, to avoid duplicate keys.
+
 ## Contributing
 
 Contributions are welcome!

--- a/test/node/objectNode.test.ts
+++ b/test/node/objectNode.test.ts
@@ -381,4 +381,60 @@ describe('ObjectNode', () => {
             key: value,
         });
     });
+
+    it.each([
+		{
+			sourceCode: `{
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */ }`,
+			destinationCode: `{
+                // Destination pre-foo comment
+                "foo": "value",
+                // Destination post-foo comment
+                "baz": [1, 2, 3] }`,
+			expected: `{			
+                // Destination pre-foo comment
+                "foo": "value",
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */ }`,
+		},
+		{
+			sourceCode: `{
+                /* Source pre-bar comment */ 
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */ }`,
+			destinationCode: `{           
+                // Destination pre-foo comment
+                "foo": "value",
+                // Destination post-foo comment
+                "fizz": 42 }`,
+			expected: `{
+                // Destination pre-foo comment
+                "foo": "value",
+                // Destination post-foo comment
+                "fizz": 42,
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */ }`,
+		},
+	])(
+		'should merge two JsonObjectNode',
+		({ sourceCode, destinationCode, expected }) => {
+			const source = JsonParser.parse(sourceCode, JsonObjectNode);
+			const destination = JsonParser.parse(destinationCode, JsonObjectNode);
+
+			const node = JsonObjectNode.merge(source, destination);
+
+			const removeWhiteSpaces = (str: string) => str.replace(/\s+/g, ' ');
+			expect(removeWhiteSpaces(node.toString())).toStrictEqual(
+				removeWhiteSpaces(expected)
+			);
+		}
+	);
 });

--- a/test/node/objectNode.test.ts
+++ b/test/node/objectNode.test.ts
@@ -3,6 +3,7 @@ import {
     JsonArrayNode,
     JsonIdentifierNode,
     JsonObjectNode,
+    JsonParser,
     JsonPrimitiveNode,
     JsonPropertyNode,
     JsonStringNode,
@@ -382,38 +383,189 @@ describe('ObjectNode', () => {
         });
     });
 
-    it.each([
-		{
-			sourceCode: `{
-                /* Source pre-bar comment */
-                "bar": 123, /* Inline comment */
-                /* Source post-bar comment */
-                "baz": true /* Another inline comment */ }`,
-			destinationCode: `{
+    type MergeScenario = {
+        description: string,
+        sourceCode: string,
+        destinationCode: string,
+        expected: string,
+    };
+
+    it.each<MergeScenario>([
+        {
+            description: 'empty source',
+            sourceCode: multiline`
+            {
+            }`,
+            destinationCode: multiline`
+            {
                 // Destination pre-foo comment
                 "foo": "value",
                 // Destination post-foo comment
-                "baz": [1, 2, 3] }`,
-			expected: `{			
-                // Destination pre-foo comment
-                "foo": "value",
-                /* Source pre-bar comment */
-                "bar": 123, /* Inline comment */
-                /* Source post-bar comment */
-                "baz": true /* Another inline comment */ }`,
-		},
-		{
-			sourceCode: `{
-                /* Source pre-bar comment */ 
-                "bar": 123, /* Inline comment */
-                /* Source post-bar comment */
-                "baz": true /* Another inline comment */ }`,
-			destinationCode: `{           
+                "baz": [1, 2, 3]
+            }`,
+            expected: multiline`
+            {
                 // Destination pre-foo comment
                 "foo": "value",
                 // Destination post-foo comment
-                "fizz": 42 }`,
-			expected: `{
+                "baz": [1, 2, 3]
+            }`,
+        },
+        {
+            description: 'empty source children',
+            sourceCode: '',
+            destinationCode: multiline`
+            {
+                // Destination pre-foo comment
+                "foo": "value",
+                // Destination post-foo comment
+                "baz": [1, 2, 3]
+            }`,
+            expected: multiline`
+            {
+                // Destination pre-foo comment
+                "foo": "value",
+                // Destination post-foo comment
+                "baz": [1, 2, 3]
+            }`,
+        },
+        {
+            description: 'empty destination',
+            sourceCode: multiline`
+            {
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */
+            }`,
+            destinationCode: multiline`
+            {
+            }`,
+            expected: multiline`
+            {
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */
+            }`,
+        },
+        {
+            description: 'empty destination children',
+            sourceCode: multiline`
+            {
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */
+            }`,
+            destinationCode: '',
+            expected: multiline`
+            {
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */
+            }`,
+        },
+        {
+            description: 'without line breaks',
+            sourceCode: multiline`
+            {/* Source pre-bar comment */ "bar": 123, /* Inline comment */}
+            `,
+            destinationCode: multiline`
+            { "foo": "value" }
+            `,
+            expected: multiline`
+            { "foo": "value","bar": 123, /* Inline comment */ }
+            `,
+        },
+        {
+            description: 'destination with multiple line breaks',
+            sourceCode: multiline`
+            {
+              /* Source pre-bar comment */ 
+              "bar": 123, /* Inline comment */
+            }
+            `,
+            destinationCode: multiline`
+            {
+              "foo": "value"
+              
+              
+            }
+            `,
+            expected: multiline`
+            {
+              "foo": "value",
+              /* Source pre-bar comment */ 
+              "bar": 123, /* Inline comment */
+              
+              
+            }
+            `,
+        },
+        {
+            description: 'destination with trailing comma and closing brace without preceding newline',
+            sourceCode: multiline`
+            {
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+            }`,
+            destinationCode: multiline`
+            {
+                // Destination pre-foo comment
+                "foo": "value",}`,
+            expected: multiline`
+            {
+                // Destination pre-foo comment
+                "foo": "value",
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */}`,
+        },
+        {
+            description: 'overlapping properties',
+            sourceCode: multiline`
+            {
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */
+            }`,
+            destinationCode: multiline`
+            {
+                // Destination pre-foo comment
+                "foo": "value",
+                // Destination post-foo comment
+                "baz": [1, 2, 3]
+            }`,
+            expected: multiline`
+            {
+                // Destination pre-foo comment
+                "foo": "value",
+                /* Source post-bar comment */
+                "baz": true, /* Another inline comment */
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+            }`,
+        },
+        {
+            description: 'disjoint properties',
+            sourceCode: multiline`
+            {
+                /* Source pre-bar comment */
+                "bar": 123, /* Inline comment */
+                /* Source post-bar comment */
+                "baz": true /* Another inline comment */
+            }`,
+            destinationCode: multiline`
+            {
+                // Destination pre-foo comment
+                "foo": "value",
+                // Destination post-foo comment
+                "fizz": 42
+            }`,
+            expected: multiline`
+            {
                 // Destination pre-foo comment
                 "foo": "value",
                 // Destination post-foo comment
@@ -421,20 +573,35 @@ describe('ObjectNode', () => {
                 /* Source pre-bar comment */
                 "bar": 123, /* Inline comment */
                 /* Source post-bar comment */
-                "baz": true /* Another inline comment */ }`,
-		},
-	])(
-		'should merge two JsonObjectNode',
-		({ sourceCode, destinationCode, expected }) => {
-			const source = JsonParser.parse(sourceCode, JsonObjectNode);
-			const destination = JsonParser.parse(destinationCode, JsonObjectNode);
+                "baz": true /* Another inline comment */
+            }`,
+        },
+    ])('should merge objects with $description', ({sourceCode, destinationCode, expected}) => {
+        const source = sourceCode === ''
+            ? JsonObjectNode.of({})
+            : JsonParser.parse(sourceCode, JsonObjectNode);
 
-			const node = JsonObjectNode.merge(source, destination);
+        const destination = destinationCode === ''
+            ? JsonObjectNode.of({})
+            : JsonParser.parse(destinationCode, JsonObjectNode);
 
-			const removeWhiteSpaces = (str: string) => str.replace(/\s+/g, ' ');
-			expect(removeWhiteSpaces(node.toString())).toStrictEqual(
-				removeWhiteSpaces(expected)
-			);
-		}
-	);
+        destination.merge(source);
+
+        expect(destination.toString()).toStrictEqual(expected);
+    });
+
+    function multiline(strings: TemplateStringsArray): string {
+        const lines = strings.join('').split('\n');
+
+        if (lines.length < 2) {
+            return strings.join('');
+        }
+
+        const indent = lines[1].search(/\S/);
+
+        return lines
+            .map(line => line.slice(indent))
+            .join('\n')
+            .trim();
+    }
 });


### PR DESCRIPTION
## Summary

This PR add JsonObjectNode merge method.
Remove any existing destination properties that clash with source, along with their leading/trailing trivia, to avoid duplicate keys.

- Close #6

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings